### PR TITLE
Feature/uninstall java

### DIFF
--- a/intune-remediations/uninstall-oracle-java/detection.ps1
+++ b/intune-remediations/uninstall-oracle-java/detection.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+Tests if Oracle Java is installed.
+.DESCRIPTION
+Tests if Oracle Java is installed by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". This is to be used as a detection script
+in an Intune remediation. If Oracle Java is found, the script will exit with a status of 1. If Oracle Java is not found, the script will exit with a status of 0. This is how Intune
+determines if the remediation is required.
+.EXAMPLE
+.\detection.ps1
+Tests if Oracle Java is installed.
+.NOTES
+File Name      : detection.ps1
+Author         : Nicholas Tabb
+Date           : 02/18/2025
+Context        : Computer (System)
+#>
+
+function Get-InstalledApplication {
+    <#
+    .SYNOPSIS
+    Get installed applications from the registry.
+    .DESCRIPTION
+    Get installed applications from the registry based on the provided name and publisher. If no publisher is provided, all applications with the provided name will be returned.
+    .PARAMETER Name
+    The name of the application to search for.
+    .PARAMETER Publisher
+    The publisher of the application to search for.
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*"
+    Searches for all applications with a name starting with "Java".
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    Searches for all applications with a name starting with "Java" and a publisher of "Oracle Corporation".    
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Publisher
+    )
+
+    $registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    $applications = $registryPaths | ForEach-Object {
+        Get-ItemProperty -Path $_ -ErrorAction SilentlyContinue
+    } | Where-Object { 
+        $_.DisplayName -like $Name -and
+        (-not $Publisher -or $_.Publisher -eq $Publisher)
+    }
+
+    return $applications
+}
+
+function Test-OracleJavaInstallation {
+    <#
+    .SYNOPSIS
+    Tests if Oracle Java is installed.
+    .DESCRIPTION
+    Tests if Oracle Java is installed by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation".
+    .EXAMPLE
+    Test-OracleJavaInstallation
+    Tests if Oracle Java is installed.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+
+    if (-not $javaApps) {
+        Write-Host "Oracle Java not found." -ForegroundColor Green
+        return $false
+    }
+    
+    Write-Host "Oracle Java found." -ForegroundColor Red
+    return $true
+}
+
+# Exit with appropriate code based on Java installation status
+exit ([int](Test-OracleJavaInstallation))

--- a/intune-remediations/uninstall-oracle-java/remediation.ps1
+++ b/intune-remediations/uninstall-oracle-java/remediation.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+Uninstalls Oracle Java applications.
+.DESCRIPTION
+Uninstalls Oracle Java applications by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". This is to be used in conjunction with 
+the detection script to remove Oracle Java from a system using Intune remediation.
+.EXAMPLE
+.\remediation.ps1
+Uninstalls Oracle Java applications.
+.NOTES
+File Name      : remediation.ps1
+Author         : Nicholas Tabb
+Date           : 02/19/2025
+Context        : Computer (System)
+#>
+
+function Get-InstalledApplication {
+    <#
+    .SYNOPSIS
+    Get installed applications from the registry.
+    .DESCRIPTION
+    Get installed applications from the registry based on the provided name and publisher. If no publisher is provided, all applications with the provided name will be returned.
+    .PARAMETER Name
+    The name of the application to search for.
+    .PARAMETER Publisher
+    The publisher of the application to search for.
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*"
+    Searches for all applications with a name starting with "Java".
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    Searches for all applications with a name starting with "Java" and a publisher of "Oracle Corporation".    
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Publisher
+    )
+
+    $registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    $applications = $registryPaths | ForEach-Object {
+        Get-ItemProperty -Path $_ -ErrorAction SilentlyContinue
+    } | Where-Object { 
+        $_.DisplayName -like $Name -and
+        (-not $Publisher -or $_.Publisher -eq $Publisher) -and
+        -not [string]::IsNullOrEmpty($_.UninstallString)
+    }
+
+    return $applications
+}
+
+function Uninstall-OracleJavaApplication {
+    <#
+    .SYNOPSIS
+    Uninstalls Oracle Java applications.
+    .DESCRIPTION
+    Uninstalls Oracle Java applications by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation".
+    .PARAMETER Application
+    The application object to uninstall. This is the registry object returned by Get-InstalledApplication.
+    .EXAMPLE
+    $javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    $javaApps | Uninstall-OracleJavaApplication
+    Uninstalls all Oracle Java applications found.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [PSObject]$Application
+    )
+
+    process {
+        try {
+            Write-Host "Attempting to uninstall $($Application.DisplayName)..." -ForegroundColor Yellow
+            
+            if ($Application.UninstallString -match "msiexec") {
+                # Handle MSI uninstalls
+                $msiCode = [regex]::Match($Application.UninstallString, '{[A-Z0-9\-]+}').Value
+                if ($msiCode) {
+                    $arguments = "/X $msiCode /qn /norestart"
+                    Start-Process "msiexec.exe" -ArgumentList $arguments -Wait -NoNewWindow
+                }
+                else {
+                    throw "Could not find MSI product code"
+                }
+            }
+            else {
+                # Handle executable uninstalls
+                $uninstallString = $Application.UninstallString
+                if ($uninstallString) {
+                    $process = Start-Process -FilePath $uninstallString -ArgumentList "/s" -Wait -PassThru -NoNewWindow
+                    if ($process.ExitCode -ne 0) {
+                        throw "Uninstall process failed with exit code: $($process.ExitCode)"
+                    }
+                }
+                else {
+                    throw "No uninstall string found"
+                }
+            }
+            
+            Write-Host "Successfully uninstalled $($Application.DisplayName)" -ForegroundColor Green
+        }
+        catch {
+            Write-Host "Failed to uninstall $($Application.DisplayName): $_" -ForegroundColor Red
+        }
+    }
+}
+
+$javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+$javaApps | Uninstall-OracleJavaApplication

--- a/sccm/configuration-baselines/uninstall-oracle-java/detection.ps1
+++ b/sccm/configuration-baselines/uninstall-oracle-java/detection.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+Tests if Oracle Java is installed.
+.DESCRIPTION
+Tests if Oracle Java is installed by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". This is used as a detection script
+in an SCCM Configuration Baseline. The script returns $true if Oracle Java is found, indicating non-compliance. Returns $false if Oracle Java is not found, indicating compliance.
+.EXAMPLE
+.\detection.ps1
+Tests if Oracle Java is installed.
+.NOTES
+File Name      : detection.ps1
+Author         : Nicholas Tabb
+Date           : 02/19/2025
+Context        : Computer (System)
+#>
+
+function Get-InstalledApplication {
+    <#
+    .SYNOPSIS
+    Get installed applications from the registry.
+    .DESCRIPTION
+    Get installed applications from the registry based on the provided name and publisher. If no publisher is provided, all applications with the provided name will be returned.
+    .PARAMETER Name
+    The name of the application to search for.
+    .PARAMETER Publisher
+    The publisher of the application to search for.
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*"
+    Searches for all applications with a name starting with "Java".
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    Searches for all applications with a name starting with "Java" and a publisher of "Oracle Corporation".    
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Publisher
+    )
+
+    $registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    $applications = $registryPaths | ForEach-Object {
+        Get-ItemProperty -Path $_ -ErrorAction SilentlyContinue
+    } | Where-Object { 
+        $_.DisplayName -like $Name -and
+        (-not $Publisher -or $_.Publisher -eq $Publisher)
+    }
+
+    return $applications
+}
+
+function Test-OracleJavaInstallation {
+    <#
+    .SYNOPSIS
+    Tests if Oracle Java is installed.
+    .DESCRIPTION
+    Tests if Oracle Java is installed by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation".
+    .EXAMPLE
+    Test-OracleJavaInstallation
+    Tests if Oracle Java is installed.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+
+    if (-not $javaApps) {
+        Write-Host "Oracle Java not found." -ForegroundColor Green
+        return $false
+    }
+    
+    Write-Host "Oracle Java found." -ForegroundColor Red
+    return $true
+}
+
+# Exit with appropriate code based on Java installation status
+# True (1) if Oracle Java is found (non-compliant), False (0) if not found (compliant)
+Test-OracleJavaInstallation

--- a/sccm/configuration-baselines/uninstall-oracle-java/remediation.ps1
+++ b/sccm/configuration-baselines/uninstall-oracle-java/remediation.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+Uninstalls Oracle Java applications.
+.DESCRIPTION
+Uninstalls Oracle Java applications by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". This script is designed to be used as 
+a remediation script in SCCM Configuration Baselines.
+.EXAMPLE
+.\remediation.ps1
+Uninstalls Oracle Java applications.
+.NOTES
+File Name      : remediation.ps1
+Author         : Nicholas Tabb
+Date           : 02/19/2025
+Run Context    : System
+#>
+
+function Get-InstalledApplication {
+    <#
+    .SYNOPSIS
+    Get installed applications from the registry.
+    .DESCRIPTION
+    Get installed applications from the registry based on the provided name and publisher. If no publisher is provided, all applications with the provided name will be returned.
+    .PARAMETER Name
+    The name of the application to search for.
+    .PARAMETER Publisher
+    The publisher of the application to search for.
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*"
+    Searches for all applications with a name starting with "Java".
+    .EXAMPLE
+    Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    Searches for all applications with a name starting with "Java" and a publisher of "Oracle Corporation".    
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Publisher
+    )
+
+    $registryPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+
+    $applications = $registryPaths | ForEach-Object {
+        Get-ItemProperty -Path $_ -ErrorAction SilentlyContinue
+    } | Where-Object { 
+        $_.DisplayName -like $Name -and
+        (-not $Publisher -or $_.Publisher -eq $Publisher) -and
+        -not [string]::IsNullOrEmpty($_.UninstallString)
+    }
+
+    return $applications
+}
+
+function Uninstall-OracleJavaApplication {
+    <#
+    .SYNOPSIS
+    Uninstalls Oracle Java applications.
+    .DESCRIPTION
+    Uninstalls Oracle Java applications by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation".
+    .PARAMETER Application
+    The application object to uninstall. This is the registry object returned by Get-InstalledApplication.
+    .EXAMPLE
+    $javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+    $javaApps | Uninstall-OracleJavaApplication
+    Uninstalls all Oracle Java applications found.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [PSObject]$Application
+    )
+
+    process {
+        try {
+            Write-Host "Attempting to uninstall $($Application.DisplayName)..." -ForegroundColor Yellow
+            
+            if ($Application.UninstallString -match "msiexec") {
+                # Handle MSI uninstalls
+                $msiCode = [regex]::Match($Application.UninstallString, '{[A-Z0-9\-]+}').Value
+                if ($msiCode) {
+                    $arguments = "/X $msiCode /qn /norestart"
+                    Start-Process "msiexec.exe" -ArgumentList $arguments -Wait -NoNewWindow
+                }
+                else {
+                    throw "Could not find MSI product code"
+                }
+            }
+            else {
+                # Handle executable uninstalls
+                $uninstallString = $Application.UninstallString
+                if ($uninstallString) {
+                    $process = Start-Process -FilePath $uninstallString -ArgumentList "/s" -Wait -PassThru -NoNewWindow
+                    if ($process.ExitCode -ne 0) {
+                        throw "Uninstall process failed with exit code: $($process.ExitCode)"
+                    }
+                }
+                else {
+                    throw "No uninstall string found"
+                }
+            }
+            
+            Write-Host "Successfully uninstalled $($Application.DisplayName)" -ForegroundColor Green
+        }
+        catch {
+            Write-Host "Failed to uninstall $($Application.DisplayName): $_" -ForegroundColor Red
+        }
+    }
+}
+
+$javaApps = Get-InstalledApplication -Name "Java*" -Publisher "Oracle Corporation"
+$javaApps | Uninstall-OracleJavaApplication


### PR DESCRIPTION
This pull request includes the addition of detection and remediation scripts for uninstalling Oracle Java applications using both Intune and SCCM Configuration Baselines. The key changes involve the creation of PowerShell scripts to detect and remove Oracle Java installations.

Detection Scripts:

* [`intune-remediations/uninstall-oracle-java/detection.ps1`](diffhunk://#diff-a09027d91ca9b807afad05c32ead975b3fb85e78dd6c1207b8af53842cdbd3f6R1-R82): Added a script to detect Oracle Java installations by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". The script exits with status 1 if Oracle Java is found, and 0 if not found.
* [`sccm/configuration-baselines/uninstall-oracle-java/detection.ps1`](diffhunk://#diff-420b47e77c608700c9ecb7f43a47eb55eb3ab80f2f0338a70663d4f6c6024d1bR1-R82): Added a script to detect Oracle Java installations for SCCM Configuration Baselines. The script returns `$true` if Oracle Java is found (non-compliant) and `$false` if not found (compliant).

Remediation Scripts:

* [`intune-remediations/uninstall-oracle-java/remediation.ps1`](diffhunk://#diff-df95abf97a37800fe6bb330a5430390d37caab14cb719237d77965e21fc26e79R1-R114): Added a script to uninstall Oracle Java applications by searching for applications with a name starting with "Java" and a publisher of "Oracle Corporation". The script handles both MSI and executable uninstalls.
* [`sccm/configuration-baselines/uninstall-oracle-java/remediation.ps1`](diffhunk://#diff-6983910b5dfc910726477da7415e1f408f15b263aa430c8cc7ec2bde09b447f6R1-R114): Added a script to uninstall Oracle Java applications for SCCM Configuration Baselines. Similar to the Intune script, it handles both MSI and executable uninstalls.